### PR TITLE
docs(readme): fix license section to state Apache 2.0 instead of MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ See [Game Phases](docs/game-phases.md) for details.
 3. Make your change, commit, and open a Pull Request.
 
 ## License
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary
docs(readme): fix license section to state Apache 2.0 instead of MIT

## Checklist
- [x] Small, self-contained change
- [x] Doesn’t break existing examples
- [x] Placed under the correct folder (`docs/`)
- [x] Follows the spirit of the game (incremental, fun)

## Notes
fix license section to state Apache 2.0 instead of MIT

---

> PRs will trigger the **CI** workflow. Once merged, contributions may be counted by the scoring service and appear on the leaderboard.